### PR TITLE
Handle ports for redirects.

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,7 +64,13 @@ function init(opts, additionalRules, additionalMiddleware, errHandler) {
     proxyServer.on("proxyRes", function (res) {
 
         if (res.statusCode === 302 || res.statusCode === 301) {
-            res.headers.location = res.headers.location.replace(opts.host, host);
+            if (opts.port == 80 || opts.port == 443) {
+              var match = opts.host;
+            }
+            else {
+              var match = opts.host + ':' + opts.port;
+            }
+            res.headers.location = res.headers.location.replace(match, host);
         }
 
         utils.removeHeaders(res.headers, ["content-length", "content-encoding"]);


### PR DESCRIPTION
Hi there,

Great module. This handles redirects when the proxy itself has a port too. For example, I run my Django server on 8000. Then this runs a proxy on 3000.

Currently, redirects sent by localhost:8000 get turned into localhost:8000:3000, which is incorrect. This should fix it.

Best,

Silvio
