### PR TITLE
cookie.parse breaks encoded cookies

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -33,7 +33,10 @@ function getProxyHost(opts) {
  */
 function rewriteCookies(rawCookie) {
 
-    var parsed = cookie.parse(rawCookie);
+    var parsed = cookie.parse(rawCookie, {decode: function(val){
+                    // Prevent values from being decodeURIComponent transformed
+                    return val;
+                }});
 
     var pairs =
             Object.keys(parsed)


### PR DESCRIPTION
cookie.parse will decodeURIComponent transform values by default.
In many cases session cookies may be encoded in various formats that breaks if the cookie value is decoded between the client and the proxy target.

Test case: https://gist.github.com/stipsan/287b5037707348e3808d

