### PR TITLE
Fix to Django login/messages (stripping double quotes)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,4 +1,4 @@
-"use stict";
+"use strict";
 
 var url         = require("url");
 var path        = require("path");
@@ -36,23 +36,36 @@ utils.getProxyHost = function getProxyHost(opts) {
  */
 utils.rewriteCookies = function rewriteCookies(rawCookie) {
 
-    var parsed = cookie.parse(rawCookie, {
-        decode: function(val) {
-            // Prevent values from being decodeURIComponent transformed
-            return val;
-        }
-    });
+    var objCookie = (function () {
+        // simple parse function (does not remove quotes)
+        var obj = {};
+        var pairs = rawCookie.split(/; */);
 
-    var pairs =
-        Object.keys(parsed)
-            .filter(function (item) {
-                return item !== "domain";
-            })
-            .map(function (key) {
-                return key + "=" + parsed[key];
-            });
+        pairs.forEach( function( pair ) {
+            var eq_idx = pair.indexOf('=');
 
-    if (rawCookie.match(/httponly/i)) {
+            // skip things that don't look like key=value
+            if (eq_idx < 0) {
+                return;
+            }
+
+            var key = pair.substr(0, eq_idx).trim();
+            var val = pair.substr(++eq_idx, pair.length).trim();
+            obj[ key ] = val;
+        });
+
+        return obj;
+    })();
+
+    var pairs = Object.keys( objCookie )
+        .filter(function (item) {
+            return item !== "domain";
+        })
+        .map(function (key) {
+            return key + "=" + objCookie[ key ];
+        });
+
+    if ( rawCookie.match(/httponly/i) ) {
         pairs.push("HttpOnly");
     }
 


### PR DESCRIPTION
Fix typo: `"use strict"`

Made `rewriteCookies` function use a simpler parser that doesn't remove double-quotes.  

Works for Django login/messages; not sure about WordPress or others, and not sure why it is filtering out domain to begin with. :)
